### PR TITLE
Only show limit price in sell token

### DIFF
--- a/src/components/TradeWidget/Price.tsx
+++ b/src/components/TradeWidget/Price.tsx
@@ -62,8 +62,8 @@ export const PriceInputBox = styled.div`
   display: flex;
   flex-flow: column nowrap;
   margin: 0;
-  width: 50%;
   width: calc(50% - 0.8rem);
+  width: 70%;
   position: relative;
   outline: 0;
 
@@ -222,7 +222,7 @@ const Price: React.FC<Props> = ({ sellToken, receiveToken, priceInputId, priceIn
       <strong>
         Limit Price <OrderBookBtn baseToken={receiveToken} quoteToken={sellToken} />
       </strong>
-      <PriceInputBox>
+      <PriceInputBox style={{ display: 'none' }}>
         <label>
           <input
             className={isError ? 'error' : ''}
@@ -257,8 +257,6 @@ const Price: React.FC<Props> = ({ sellToken, receiveToken, priceInputId, priceIn
             tabIndex={tabIndex}
           />
           <div>
-            <small title={receiveToken.symbol}>{receiveToken.symbol}</small>
-            <small>/</small>
             <small title={sellToken.symbol}>{sellToken.symbol}</small>
           </div>
         </label>


### PR DESCRIPTION
As a quick fix to limit user confusion, hide first box and only show the price quoted in the sell token.

<img width="556" alt="Screen Shot 2020-06-21 at 2 41 05 PM" src="https://user-images.githubusercontent.com/874683/85232512-44abd180-b3cd-11ea-8401-7634f29ee5b3.png">
